### PR TITLE
fix: protect dashboard routes with authentication middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ NEXT_PUBLIC_FIREBASE_APP_ID=#1:736891312580:web:2752bc815204c69fcbec91
 
 NEXT_PUBLIC_HASURA_GRAPHQL_URL=#http://localhost:8080/v1/graphql
 NEXT_PUBLIC_HASURA_ADMIN_SECRET=#myadminsecretkey
+
+# Development-only bypass for the route authentication middleware.
+# Keep false or unset in production.
+NEXT_PUBLIC_SKIP_AUTH_MIDDLEWARE=false

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PROTECTED_PREFIXES = ["/dashboard", "/guest"];
+
+const PUBLIC_PATHS = new Set([
+  "/",
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/new-password",
+  "/reset-password",
+  "/verify-email",
+  "/rent",
+]);
+
+function isProtected(pathname: string): boolean {
+  if (PUBLIC_PATHS.has(pathname)) return false;
+
+  // Rental and room pages are public, including their nested routes.
+  if (pathname.startsWith("/rent/") || pathname.startsWith("/room/")) {
+    return false;
+  }
+
+  // Next.js internals and static assets should pass through untouched.
+  if (
+    pathname.startsWith("/_next/") ||
+    pathname.startsWith("/api/") ||
+    pathname.startsWith("/img/") ||
+    pathname.startsWith("/styles/") ||
+    pathname.includes(".")
+  ) {
+    return false;
+  }
+
+  return PROTECTED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function middleware(req: NextRequest) {
+  if (process.env.NEXT_PUBLIC_SKIP_AUTH_MIDDLEWARE === "true") {
+    return NextResponse.next();
+  }
+
+  const { pathname } = req.nextUrl;
+
+  if (!isProtected(pathname)) {
+    return NextResponse.next();
+  }
+
+  // Firebase Admin cannot run in Next.js Edge middleware. The token is
+  // verified server-side by the auth API, while middleware checks presence.
+  const token = req.cookies.get("firebase-token")?.value;
+
+  if (!token) {
+    const loginUrl = new URL("/login", req.url);
+    loginUrl.searchParams.set("redirect", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,6 +21,15 @@ function isProtected(pathname: string): boolean {
     return false;
   }
 
+  // Protected routes must take precedence over static-file exclusions.
+  if (
+    PROTECTED_PREFIXES.some(
+      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+    )
+  ) {
+    return true;
+  }
+
   // Next.js internals and static assets should pass through untouched.
   if (
     pathname.startsWith("/_next/") ||
@@ -32,9 +41,7 @@ function isProtected(pathname: string): boolean {
     return false;
   }
 
-  return PROTECTED_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
-  );
+  return false;
 }
 
 export function middleware(req: NextRequest) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,10 @@ const PUBLIC_PATHS = new Set([
   "/rent",
 ]);
 
+/**
+ * Determines whether a request targets an authenticated application route.
+ * Public pages and static assets are excluded before protected prefixes are checked.
+ */
 function isProtected(pathname: string): boolean {
   if (PUBLIC_PATHS.has(pathname)) return false;
 
@@ -44,6 +48,10 @@ function isProtected(pathname: string): boolean {
   return false;
 }
 
+/**
+ * Enforces the lightweight Edge-compatible Firebase cookie check for protected routes.
+ * Token signature verification remains in the server-side authentication boundary.
+ */
 export function middleware(req: NextRequest) {
   if (process.env.NEXT_PUBLIC_SKIP_AUTH_MIDDLEWARE === "true") {
     return NextResponse.next();


### PR DESCRIPTION
## Summary

- add Next.js middleware to protect `/dashboard` and `/guest` routes
- redirect unauthenticated requests to `/login` with the destination preserved
- allow public auth, rental, room, static, and API routes through
- document the development-only `NEXT_PUBLIC_SKIP_AUTH_MIDDLEWARE` flag

## Testing

- `git diff --check` passed
- Automated checks could not run because dependency installation was interrupted by a stalled npm package download

Fixes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added route protection for dashboard and guest areas.
  * Unauthenticated visitors are redirected to the login page and returned to their intended destination afterward.
  * Public pages and static assets remain accessible without authentication.
  * Authenticated visitors can continue to access protected areas normally.
  * Added a development-only option to bypass authentication middleware; it remains disabled by default and should not be enabled in production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->