### PR TITLE
feat(dashboard): implement WishlistCard and favorites page (#446)

### DIFF
--- a/src/app/dashboard/favorites/page.tsx
+++ b/src/app/dashboard/favorites/page.tsx
@@ -1,77 +1,85 @@
-import FavoriteButton from '@/components/room/mobile/FavoriteButton';
+"use client";
 
-const STUB_FAVORITES = [
+import { useRouter } from "next/navigation";
+import { Heart } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { WishlistCard } from "@/components/dashboard/WishlistCard";
+import { MOCK_APARTMENTS } from "@/lib/mockData/apartments";
+
+// TODO: replace with Hasura query → public.favorites
+//       WHERE user_id = currentUser.id
+const STUB_WISHLISTS = [
   {
-    id: '1',
-    name: 'La sabana sur',
-    address: '329 Calle santos, paseo colón, San José',
-    price: 4058,
-    bedrooms: 2,
-    bathrooms: 1,
-    petFriendly: true,
+    id: "wl-1",
+    name: "Recently viewed",
+    savedAt: "Today",
+    apartments: MOCK_APARTMENTS.slice(0, 4),
   },
   {
-    id: '2',
-    name: 'Los yoses',
-    address: '329 Calle santos, paseo colón, San José',
-    price: 4000,
-    bedrooms: 2,
-    bathrooms: 1,
-    petFriendly: true,
+    id: "wl-2",
+    name: "La Sabana picks",
+    savedAt: "Yesterday",
+    apartments: MOCK_APARTMENTS.slice(1, 5),
+  },
+  {
+    id: "wl-3",
+    name: "Escazú options",
+    savedAt: "3 days ago",
+    apartments: MOCK_APARTMENTS.slice(2, 6),
   },
 ];
 
 export default function FavoritesPage() {
-  return (
-    <div className="p-6 space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">Favorites</h1>
-        <p className="text-muted-foreground text-sm mt-1">
-          Apartments you have saved
-        </p>
-      </div>
+  const router = useRouter();
 
-      {STUB_FAVORITES.length === 0 ? (
-        <div className="text-center py-16 text-muted-foreground">
-          <p className="text-lg font-medium">No favorites yet</p>
-          <p className="text-sm mt-1">
-            Save apartments by clicking the heart icon on any listing.
+  return (
+    <div className="max-w-5xl mx-auto space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">My Wishlist</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {STUB_WISHLISTS.length} saved
           </p>
         </div>
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {STUB_FAVORITES.map((apartment) => (
-            <div
-              key={apartment.id}
-              className="border rounded-xl p-4 bg-card space-y-3"
-            >
-              <div className="h-32 bg-muted rounded-lg flex items-center justify-center">
-                <span className="text-xs text-muted-foreground">
-                  Image placeholder
-                </span>
-              </div>
+        <Button
+          variant="outline"
+          onClick={() => router.push("/rent")}
+          className="text-sm"
+        >
+          Browse apartments
+        </Button>
+      </div>
 
-              <div className="flex items-start justify-between gap-2">
-                <div>
-                  <p className="font-semibold">{apartment.name}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {apartment.address}
-                  </p>
-                  <p className="text-sm text-primary font-semibold mt-1">
-                    ${apartment.price.toLocaleString()}/mo
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    {apartment.bedrooms}bd ·{' '}
-                    {apartment.petFriendly ? 'pet friendly' : 'no pets'} ·{' '}
-                    {apartment.bathrooms}ba
-                  </p>
-                </div>
-
-                {/* TODO: wire isLiked state from user favorites store */}
-                <FavoriteButton isLiked={true} showCount={false} />
-              </div>
-            </div>
+      {/* Grid */}
+      {STUB_WISHLISTS.length > 0 ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {STUB_WISHLISTS.map((wl) => (
+            <WishlistCard
+              key={wl.id}
+              name={wl.name}
+              apartments={wl.apartments}
+              savedAt={wl.savedAt}
+              onClick={() => router.push("/rent")}
+            />
           ))}
+        </div>
+      ) : (
+        /* Empty state */
+        <div className="flex flex-col items-center justify-center py-24 space-y-4 text-center">
+          <Heart className="h-12 w-12 text-muted-foreground" />
+          <p className="text-lg font-medium text-foreground">
+            No saved apartments yet
+          </p>
+          <p className="text-sm text-muted-foreground max-w-xs">
+            Browse apartments and tap the heart icon to save them to your wishlist.
+          </p>
+          <Button
+            onClick={() => router.push("/rent")}
+            className="bg-orange-500 hover:bg-orange-600 text-white"
+          >
+            Browse apartments →
+          </Button>
         </div>
       )}
     </div>

--- a/src/components/dashboard/WishlistCard.test.tsx
+++ b/src/components/dashboard/WishlistCard.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WishlistCard } from "./WishlistCard";
+import FavoritesPage from "@/app/dashboard/favorites/page";
+import type { Apartment } from "@/lib/mockData/apartments";
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+const mockApartments: Apartment[] = [
+  {
+    id: "apt-1",
+    name: "Apartment 1",
+    price: 1000,
+    warranty_deposit: 2000,
+    is_available: true,
+    image_urls: ["/img/room1.png", "/img/room2.png"],
+    address: { city: "San José" },
+    location: "San José",
+    offers: 1,
+    status: "inhabited",
+    promoted: true,
+    available_from: "2026-01-01",
+    created_at: "2026-01-01",
+    owner_id: "owner-1",
+  },
+  {
+    id: "apt-2",
+    name: "Apartment 2",
+    price: 1500,
+    warranty_deposit: 3000,
+    is_available: true,
+    image_urls: ["/img/room3.png"],
+    address: { city: "Escazú" },
+    location: "Escazú",
+    offers: 0,
+    status: "inhabited",
+    promoted: false,
+    available_from: "2026-01-01",
+    created_at: "2026-01-01",
+    owner_id: "owner-2",
+  },
+];
+
+describe("WishlistCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders collection name and savedAt timestamp correctly", () => {
+    render(
+      <WishlistCard
+        name="Recently viewed"
+        savedAt="Today"
+        apartments={mockApartments}
+      />
+    );
+
+    expect(screen.getByText("Recently viewed")).toBeInTheDocument();
+    expect(screen.getByText("Today")).toBeInTheDocument();
+  });
+
+  it("triggers onClick callback when clicked", () => {
+    const handleClick = jest.fn();
+    render(
+      <WishlistCard
+        name="Escazú picks"
+        savedAt="Yesterday"
+        apartments={mockApartments}
+        onClick={handleClick}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Escazú picks"));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("FavoritesPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the page title and stub wishlist collections", () => {
+    render(<FavoritesPage />);
+
+    expect(screen.getByText("My Wishlist")).toBeInTheDocument();
+    expect(screen.getByText("3 saved")).toBeInTheDocument();
+    expect(screen.getByText("Recently viewed")).toBeInTheDocument();
+    expect(screen.getByText("La Sabana picks")).toBeInTheDocument();
+    expect(screen.getByText("Escazú options")).toBeInTheDocument();
+  });
+
+  it("navigates to /rent when browse apartments button is clicked", () => {
+    render(<FavoritesPage />);
+
+    const browseBtn = screen.getByRole("button", { name: /browse apartments/i });
+    fireEvent.click(browseBtn);
+
+    expect(mockPush).toHaveBeenCalledWith("/rent");
+  });
+
+  it("navigates to /rent when a wishlist card is clicked", () => {
+    render(<FavoritesPage />);
+
+    const card = screen.getByText("Recently viewed");
+    fireEvent.click(card);
+
+    expect(mockPush).toHaveBeenCalledWith("/rent");
+  });
+});

--- a/src/components/dashboard/WishlistCard.tsx
+++ b/src/components/dashboard/WishlistCard.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { Apartment } from "@/lib/mockData/apartments";
+
+export interface WishlistCardProps {
+  name: string;
+  apartments: Apartment[];
+  savedAt: string;
+  onClick?: () => void;
+}
+
+export function WishlistCard({
+  name,
+  apartments,
+  savedAt,
+  onClick,
+}: WishlistCardProps) {
+  const images = apartments
+    .flatMap((a) => a.image_urls ?? [])
+    .filter(Boolean)
+    .slice(0, 4);
+
+  // Pad to 4 slots with placeholder gray
+  while (images.length < 4) images.push("");
+
+  return (
+    <div
+      onClick={onClick}
+      className="cursor-pointer group rounded-2xl overflow-hidden hover:shadow-md transition-shadow"
+    >
+      {/* 2x2 image mosaic */}
+      <div className="grid grid-cols-2 gap-0.5 aspect-square rounded-2xl overflow-hidden">
+        {images.map((src, i) => (
+          <div key={i} className="bg-muted overflow-hidden">
+            {src ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={src}
+                alt=""
+                className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = "none";
+                }}
+              />
+            ) : (
+              <div className="w-full h-full bg-muted" />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Info */}
+      <div className="pt-3 space-y-0.5">
+        <p className="text-sm font-semibold text-foreground">{name}</p>
+        <p className="text-xs text-muted-foreground">{savedAt}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #446

## Summary
- Implemented WishlistCard component in src/components/dashboard/WishlistCard.tsx featuring 2x2 image mosaic and metadata display (collection name, relative timestamp).
- Updated /dashboard/favorites page (src/app/dashboard/favorites/page.tsx) to render responsive grid of wishlist cards with stub collections and an empty state when no saved apartments exist.
- Added comprehensive unit and component tests in src/components/dashboard/WishlistCard.test.tsx verifying card rendering, navigation handlers, and click callbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wishlist collections to the Favorites page, displayed as visual cards with apartment mosaics and saved dates.
  * Added navigation to browse apartments from the header and empty state.
  * Added an empty state with a “Browse apartments” call to action when no wishlists are available.

* **Tests**
  * Added coverage for wishlist card rendering, interactions, and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->