### PR TITLE
feat: add message host action to guest suggestions and rent views

### DIFF
--- a/src/app/guest/suggestions/page.test.tsx
+++ b/src/app/guest/suggestions/page.test.tsx
@@ -1,0 +1,55 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import GuestSuggestionsPage from "./page";
+import { useRouter } from "next/navigation";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-image" />,
+}));
+
+jest.mock("@/components/hotel/HotelHeader", () => ({
+  __esModule: true,
+  default: () => <header data-testid="hotel-header" />,
+}));
+
+const mockPush = jest.fn();
+
+describe("GuestSuggestionsPage – Message host", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+  });
+
+  it("renders the Message host button next to Book for the selected apartment", () => {
+    render(<GuestSuggestionsPage />);
+
+    expect(screen.getByRole("button", { name: /Book/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Message host/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("navigates to the conversation thread for the selected apartment", () => {
+    render(<GuestSuggestionsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Message host/i }));
+
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/messages/conv-10");
+  });
+
+  it("updates the target conversation when another apartment is selected", () => {
+    render(<GuestSuggestionsPage />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Suite Ejecutiva Sabana Norte/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Message host/i }));
+
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/messages/conv-11");
+  });
+});

--- a/src/app/guest/suggestions/page.tsx
+++ b/src/app/guest/suggestions/page.tsx
@@ -4,9 +4,10 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Heart, MapPin, Bed, PawPrint, Bath } from "lucide-react";
+import { Heart, MapPin, Bed, PawPrint, Bath, MessageCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import  HotelHeader from "@/components/hotel/HotelHeader";
+import { getConversationIdForApartment } from "@/lib/mockData/messages";
 
 // TODO: replace with Apollo query → public.apartments (Hasura)
 // Reference: dApp/apps/frontend/src/app/dashboard/guest/page.tsx
@@ -57,6 +58,7 @@ export default function GuestSuggestionsPage() {
   const [favorites, setFavorites] = useState<string[]>([]);
 
   const selected = STUB_APARTMENTS.find((a) => a.id === selectedId)!;
+  const selectedConversationId = getConversationIdForApartment(selected.name);
 
   const toggleFavorite = (id: string) => {
     setFavorites((curr) =>
@@ -257,17 +259,35 @@ export default function GuestSuggestionsPage() {
                 </p>
               </div>
 
-              <button
-                onClick={() => {
-                  router.push(`/rent/${selected.id}/escrow/create`);
-                }}
-                className="rounded-xl bg-orange-500 hover:bg-orange-600
-                           active:bg-orange-700 text-white font-bold
-                           uppercase tracking-wide px-8 py-3
-                           transition-colors duration-200 shadow-md"
-              >
-                Book
-              </button>
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  onClick={() => {
+                    router.push(`/rent/${selected.id}/escrow/create`);
+                  }}
+                  className="rounded-xl bg-orange-500 hover:bg-orange-600
+                             active:bg-orange-700 text-white font-bold
+                             uppercase tracking-wide px-8 py-3
+                             transition-colors duration-200 shadow-md"
+                >
+                  Book
+                </button>
+                {selectedConversationId && (
+                  <button
+                    onClick={() => {
+                      router.push(`/dashboard/messages/${selectedConversationId}`);
+                    }}
+                    className="rounded-xl border border-orange-500
+                               text-orange-500 hover:bg-orange-50
+                               dark:hover:bg-orange-900/10 font-semibold
+                               uppercase tracking-wide px-6 py-3
+                               transition-colors duration-200
+                               inline-flex items-center gap-2"
+                  >
+                    <MessageCircle className="h-4 w-4" aria-hidden="true" />
+                    Message host
+                  </button>
+                )}
+              </div>
             </div>
           </main>
 

--- a/src/components/hotel/ApartmentCard.test.tsx
+++ b/src/components/hotel/ApartmentCard.test.tsx
@@ -1,0 +1,55 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import ApartmentCard from "./ApartmentCard";
+import { STUB_HOTELS } from "@/lib/mockData/hotels";
+import { useRouter } from "next/navigation";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+const mockPush = jest.fn();
+
+describe("ApartmentCard – Message host", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+  });
+
+  it("renders Book and Message host for a mapped apartment", () => {
+    render(<ApartmentCard apartment={STUB_HOTELS[0]} />);
+
+    expect(screen.getByRole("button", { name: /Book/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Message host/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("navigates to the matching conversation thread when Message host is clicked", () => {
+    render(<ApartmentCard apartment={STUB_HOTELS[0]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Message host/i }));
+
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/messages/conv-4");
+  });
+
+  it("does not trigger the card onClick when Message host is clicked", () => {
+    const onClick = jest.fn();
+    render(<ApartmentCard apartment={STUB_HOTELS[0]} onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Message host/i }));
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/messages/conv-4");
+  });
+
+  it("hides the Message host button when no conversation exists for the apartment", () => {
+    const unmapped = { ...STUB_HOTELS[0], name: "Nonexistent Villa" };
+    render(<ApartmentCard apartment={unmapped} />);
+
+    expect(screen.getByRole("button", { name: /Book/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Message host/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/hotel/ApartmentCard.tsx
+++ b/src/components/hotel/ApartmentCard.tsx
@@ -3,10 +3,13 @@
 import type { HotelListing } from "@/@types/hotel";
 import { cn } from "@/lib/utils";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { AiOutlineHeart } from "react-icons/ai";
 import { FaFireAlt } from "react-icons/fa";
+import { MessageCircle } from "lucide-react";
 import AmenityIcons from "./AmenityIcons";
 import { formatListingPrice } from "./formatListingPrice";
+import { getConversationIdForApartment } from "@/lib/mockData/messages";
 
 interface ApartmentCardProps {
   apartment: HotelListing;
@@ -17,6 +20,9 @@ export default function ApartmentCard({
   apartment,
   onClick,
 }: ApartmentCardProps) {
+  const router = useRouter();
+  const conversationId = getConversationIdForApartment(apartment.name);
+
   return (
     <div
       onClick={onClick}
@@ -84,8 +90,23 @@ export default function ApartmentCard({
         >
           Book
         </button>
+        {conversationId && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              router.push(`/dashboard/messages/${conversationId}`);
+            }}
+            className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg
+                       border border-orange-500 py-2 px-4 text-sm font-semibold
+                       text-orange-500 transition-colors duration-200
+                       hover:bg-orange-50 dark:hover:bg-orange-900/10"
+          >
+            <MessageCircle className="h-4 w-4" aria-hidden="true" />
+            Message host
+          </button>
+        )}
       </div>
     </div>
   );
 }
-

--- a/src/lib/mockData/messages.test.ts
+++ b/src/lib/mockData/messages.test.ts
@@ -1,0 +1,29 @@
+import { getConversationIdForApartment } from "./messages";
+
+describe("getConversationIdForApartment", () => {
+  it("maps every /rent listing to a stub conversation", () => {
+    expect(getConversationIdForApartment("La sabana sur")).toBe("conv-4");
+    expect(getConversationIdForApartment("Los yoses")).toBe("conv-5");
+    expect(getConversationIdForApartment("Paseo Colón Loft")).toBe("conv-6");
+    expect(getConversationIdForApartment("Heredia Central")).toBe("conv-7");
+    expect(getConversationIdForApartment("Alajuela Heights")).toBe("conv-8");
+    expect(getConversationIdForApartment("Cartago View")).toBe("conv-9");
+  });
+
+  it("maps every /guest/suggestions apartment to a stub conversation", () => {
+    expect(getConversationIdForApartment("Moderno Apartamento en San José Centro")).toBe(
+      "conv-10",
+    );
+    expect(getConversationIdForApartment("Suite Ejecutiva Sabana Norte")).toBe(
+      "conv-11",
+    );
+  });
+
+  it("matches case-insensitively and trims whitespace", () => {
+    expect(getConversationIdForApartment("  LA SABANA SUR  ")).toBe("conv-4");
+  });
+
+  it("returns undefined for an unknown apartment", () => {
+    expect(getConversationIdForApartment("Nonexistent Villa")).toBeUndefined();
+  });
+});

--- a/src/lib/mockData/messages.ts
+++ b/src/lib/mockData/messages.ts
@@ -71,7 +71,201 @@ export const MOCK_CONVERSATIONS = [
       },
     ],
   },
+  // Guest-view apartments (issue #447): one stub conversation per apartment
+  // shown on /guest/suggestions and /rent, so "Message host" always lands on
+  // a matching thread.
+  {
+    id: "conv-4",
+    last_message_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    apartment: { name: "La sabana sur" },
+    host: {
+      id: "mock-host-4",
+      first_name: "Alberto",
+      last_name: "Casas",
+    },
+    guest: {
+      id: "mock-guest-1",
+      first_name: "Guest",
+      last_name: "User",
+    },
+    messages: [
+      {
+        body: "Hi, is this apartment available?",
+        created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+        sender: { first_name: "Guest" },
+      },
+    ],
+  },
+  {
+    id: "conv-5",
+    last_message_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    apartment: { name: "Los yoses" },
+    host: {
+      id: "mock-host-5",
+      first_name: "Randall",
+      last_name: "Valenciano",
+    },
+    guest: {
+      id: "mock-guest-1",
+      first_name: "Guest",
+      last_name: "User",
+    },
+    messages: [
+      {
+        body: "Hi, is this apartment available?",
+        created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+        sender: { first_name: "Guest" },
+      },
+    ],
+  },
+  {
+    id: "conv-6",
+    last_message_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    apartment: { name: "Paseo Colón Loft" },
+    host: {
+      id: "mock-host-6",
+      first_name: "María",
+      last_name: "López",
+    },
+    guest: {
+      id: "mock-guest-1",
+      first_name: "Guest",
+      last_name: "User",
+    },
+    messages: [
+      {
+        body: "Hi, is this apartment available?",
+        created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+        sender: { first_name: "Guest" },
+      },
+    ],
+  },
+  {
+    id: "conv-7",
+    last_message_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    apartment: { name: "Heredia Central" },
+    host: {
+      id: "mock-host-7",
+      first_name: "Luis",
+      last_name: "Salas",
+    },
+    guest: {
+      id: "mock-guest-1",
+      first_name: "Guest",
+      last_name: "User",
+    },
+    messages: [
+      {
+        body: "Hi, is this apartment available?",
+        created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+        sender: { first_name: "Guest" },
+      },
+    ],
+  },
+  {
+    id: "conv-8",
+    last_message_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    apartment: { name: "Alajuela Heights" },
+    host: {
+      id: "mock-host-8",
+      first_name: "Ana",
+      last_name: "Ruiz",
+    },
+    guest: {
+      id: "mock-guest-1",
+      first_name: "Guest",
+      last_name: "User",
+    },
+    messages: [
+      {
+        body: "Hi, is this apartment available?",
+        created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+        sender: { first_name: "Guest" },
+      },
+    ],
+  },
+  {
+    id: "conv-9",
+    last_message_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    apartment: { name: "Cartago View" },
+    host: {
+      id: "mock-host-9",
+      first_name: "Sofía",
+      last_name: "Mora",
+    },
+    guest: {
+      id: "mock-guest-1",
+      first_name: "Guest",
+      last_name: "User",
+    },
+    messages: [
+      {
+        body: "Hi, is this apartment available?",
+        created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+        sender: { first_name: "Guest" },
+      },
+    ],
+  },
+  {
+    id: "conv-10",
+    last_message_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    apartment: { name: "Moderno Apartamento en San José Centro" },
+    host: {
+      id: "mock-host-10",
+      first_name: "Carlos",
+      last_name: "Méndez",
+    },
+    guest: {
+      id: "mock-guest-1",
+      first_name: "Guest",
+      last_name: "User",
+    },
+    messages: [
+      {
+        body: "Hi, is this apartment available?",
+        created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+        sender: { first_name: "Guest" },
+      },
+    ],
+  },
+  {
+    id: "conv-11",
+    last_message_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    apartment: { name: "Suite Ejecutiva Sabana Norte" },
+    host: {
+      id: "mock-host-11",
+      first_name: "Andrés",
+      last_name: "Vega",
+    },
+    guest: {
+      id: "mock-guest-1",
+      first_name: "Guest",
+      last_name: "User",
+    },
+    messages: [
+      {
+        body: "Hi, is this apartment available?",
+        created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+        sender: { first_name: "Guest" },
+      },
+    ],
+  },
 ];
+
+/**
+ * Resolve the stub conversation for an apartment shown in the guest browse
+ * views (/guest/suggestions and /rent). Matching is case-insensitive against
+ * the apartment names in MOCK_CONVERSATIONS.
+ */
+export function getConversationIdForApartment(
+  apartmentName: string,
+): string | undefined {
+  const normalized = apartmentName.trim().toLowerCase();
+  return MOCK_CONVERSATIONS.find(
+    (conversation) =>
+      conversation.apartment.name.trim().toLowerCase() === normalized,
+  )?.id;
+}
 
 export type MockMessage = {
   id: string;

--- a/src/lib/mockData/messages.ts
+++ b/src/lib/mockData/messages.ts
@@ -387,4 +387,132 @@ export const MOCK_MESSAGES: Record<string, MockMessage[]> = {
       },
     },
   ],
+  "conv-4": [
+    {
+      id: "msg-8",
+      body: "Hi, is this apartment available?",
+      is_automated: false,
+      event_type: null,
+      read_at: null,
+      created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      sender: {
+        id: "mock-guest-1",
+        first_name: "Guest",
+        last_name: "User",
+        email: "guest@test.com",
+      },
+    },
+  ],
+  "conv-5": [
+    {
+      id: "msg-9",
+      body: "Hi, is this apartment available?",
+      is_automated: false,
+      event_type: null,
+      read_at: null,
+      created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      sender: {
+        id: "mock-guest-1",
+        first_name: "Guest",
+        last_name: "User",
+        email: "guest@test.com",
+      },
+    },
+  ],
+  "conv-6": [
+    {
+      id: "msg-10",
+      body: "Hi, is this apartment available?",
+      is_automated: false,
+      event_type: null,
+      read_at: null,
+      created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      sender: {
+        id: "mock-guest-1",
+        first_name: "Guest",
+        last_name: "User",
+        email: "guest@test.com",
+      },
+    },
+  ],
+  "conv-7": [
+    {
+      id: "msg-11",
+      body: "Hi, is this apartment available?",
+      is_automated: false,
+      event_type: null,
+      read_at: null,
+      created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      sender: {
+        id: "mock-guest-1",
+        first_name: "Guest",
+        last_name: "User",
+        email: "guest@test.com",
+      },
+    },
+  ],
+  "conv-8": [
+    {
+      id: "msg-12",
+      body: "Hi, is this apartment available?",
+      is_automated: false,
+      event_type: null,
+      read_at: null,
+      created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      sender: {
+        id: "mock-guest-1",
+        first_name: "Guest",
+        last_name: "User",
+        email: "guest@test.com",
+      },
+    },
+  ],
+  "conv-9": [
+    {
+      id: "msg-13",
+      body: "Hi, is this apartment available?",
+      is_automated: false,
+      event_type: null,
+      read_at: null,
+      created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      sender: {
+        id: "mock-guest-1",
+        first_name: "Guest",
+        last_name: "User",
+        email: "guest@test.com",
+      },
+    },
+  ],
+  "conv-10": [
+    {
+      id: "msg-14",
+      body: "Hi, is this apartment available?",
+      is_automated: false,
+      event_type: null,
+      read_at: null,
+      created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      sender: {
+        id: "mock-guest-1",
+        first_name: "Guest",
+        last_name: "User",
+        email: "guest@test.com",
+      },
+    },
+  ],
+  "conv-11": [
+    {
+      id: "msg-15",
+      body: "Hi, is this apartment available?",
+      is_automated: false,
+      event_type: null,
+      read_at: null,
+      created_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      sender: {
+        id: "mock-guest-1",
+        first_name: "Guest",
+        last_name: "User",
+        email: "guest@test.com",
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Closes #447

## Summary

Adds a **"Message host"** action to both guest browse views so a guest can contact a host before or after booking:

- `/guest/suggestions` — a secondary "Message host" button next to **BOOK** in the apartment detail panel.
- `/rent` — a "Message host" button below **Book** on every apartment card.

Clicking either navigates to the matching stub conversation at `/dashboard/messages/[conversationId]`.

## Changes

- `src/lib/mockData/messages.ts`
  - Extended `MOCK_CONVERSATIONS` with a stub conversation for every apartment shown on `/guest/suggestions` and `/rent` (`conv-4`..`conv-11`), so the opened thread always matches the apartment name and host.
  - Added `getConversationIdForApartment(apartmentName)` — case-insensitive name lookup over `MOCK_CONVERSATIONS`.
- `src/app/guest/suggestions/page.tsx` — "Message host" button next to **BOOK**, navigating to the selected apartment's conversation.
- `src/components/hotel/ApartmentCard.tsx` — "Message host" button below **Book** (self-contained navigation; hidden when no conversation exists for the apartment).

## Tests

- `src/lib/mockData/messages.test.ts` — every guest-view apartment resolves to a conversation; case-insensitive/trimmed matching; unknown apartment returns `undefined`.
- `src/components/hotel/ApartmentCard.test.tsx` — renders Book + Message host, navigates to the matching thread, does not trigger the card `onClick`, hides the button for unmapped apartments.
- `src/app/guest/suggestions/page.test.tsx` — renders the button next to Book, navigates to the default apartment's conversation, and updates the target when another apartment is selected.

All 11 new tests pass; the changed files are lint-clean.

## Notes

- No API, routing, or auth behavior changes; the dashboard messages view (`/dashboard/messages/[conversationId]`) is untouched and renders the mapped conversation via the existing `ConversationThread`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Message host” option to apartment cards and guest suggestions.
  * Guests can open the relevant conversation directly from an apartment listing.
  * The existing booking action remains available.

* **Bug Fixes**
  * Prevented message-button clicks from unintentionally selecting the apartment card.

* **Tests**
  * Added coverage for messaging navigation, apartment matching, and unavailable conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->