### PR TITLE
Connect rent browsing and guest suggestions views

### DIFF
--- a/src/app/rent/page.tsx
+++ b/src/app/rent/page.tsx
@@ -3,11 +3,12 @@
 import type { HotelListing } from "@/@types/hotel";
 import { ApartmentGrid, BedroomTabs, FilterSidebar, HotelHeader } from "@/components/hotel";
 import { STUB_HOTELS } from "@/lib/mockData/hotels";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { BsSortDownAlt } from "react-icons/bs";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { SlidersHorizontal } from "lucide-react";
+import { Lightbulb, SlidersHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type SortOption = "relevance" | "price-low" | "price-high";
@@ -94,6 +95,14 @@ export default function HotelListingPage() {
               <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">204 units available</p>
             </div>
 
+            <div className="flex flex-wrap items-center gap-4">
+              <Link
+                href="/guest/suggestions"
+                className="flex items-center gap-1.5 text-sm font-medium text-orange-500 transition-colors hover:text-orange-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+              >
+                <Lightbulb aria-hidden="true" className="h-4 w-4" />
+                Suggestions view
+              </Link>
             <Popover>
               <PopoverTrigger asChild>
                 <button className="flex items-center gap-2 text-sm
@@ -270,6 +279,7 @@ export default function HotelListingPage() {
                 </button>
               </PopoverContent>
             </Popover>
+            </div>
           </div>
 
           <div className="mt-6">

--- a/src/components/hotel/HotelHeader.test.tsx
+++ b/src/components/hotel/HotelHeader.test.tsx
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import HotelHeader from './HotelHeader';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+}));
+
+jest.mock('@/components/ui/ThemeToggle', () => ({
+  ThemeToggle: () => <button type="button">Theme</button>,
+}));
+
+describe('HotelHeader rent navigation', () => {
+  it('exposes all rent destinations and closes after selection', () => {
+    render(<HotelHeader />);
+    const trigger = screen.getByRole('button', { name: 'Rent' });
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('menuitem', { name: /browse all units/i })).toHaveAttribute('href', '/rent');
+    expect(screen.getByRole('menuitem', { name: /^suggestions/i })).toHaveAttribute('href', '/guest/suggestions');
+    expect(screen.getByRole('menuitem', { name: /my wishlist/i })).toHaveAttribute('href', '/dashboard/favorites');
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /browse all units/i }));
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('closes on outside click', () => {
+    render(<HotelHeader />);
+    const trigger = screen.getByRole('button', { name: 'Rent' });
+    fireEvent.click(trigger);
+    fireEvent.mouseDown(document.body);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('closes on Escape and restores focus to the trigger', () => {
+    render(<HotelHeader />);
+    const trigger = screen.getByRole('button', { name: 'Rent' });
+    fireEvent.click(trigger);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/src/components/hotel/HotelHeader.tsx
+++ b/src/components/hotel/HotelHeader.tsx
@@ -2,16 +2,110 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import { ChevronDown, Grid2X2, Heart, Lightbulb } from 'lucide-react';
 import {
   FaBell,
-  FaChevronDown,
   FaRegUserCircle,
   FaSearch,
 } from 'react-icons/fa';
 
 interface HotelHeaderProps {
   showHostSwitch?: boolean;
+}
+
+const RENT_ITEMS = [
+  {
+    icon: Grid2X2,
+    label: 'Browse all units',
+    description: 'Filter by price, location, rooms',
+    href: '/rent',
+  },
+  {
+    icon: Lightbulb,
+    label: 'Suggestions',
+    description: 'Curated picks with detail view',
+    href: '/guest/suggestions',
+  },
+  {
+    icon: Heart,
+    label: 'My Wishlist',
+    description: 'Your saved apartments',
+    href: '/dashboard/favorites',
+  },
+] as const;
+
+export function RentDropdown() {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const closeOnOutsideClick = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && open) {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('mousedown', closeOnOutsideClick);
+    document.addEventListener('keydown', closeOnEscape);
+    return () => {
+      document.removeEventListener('mousedown', closeOnOutsideClick);
+      document.removeEventListener('keydown', closeOnEscape);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls="rent-navigation-menu"
+        onClick={() => setOpen((current) => !current)}
+        className="flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm text-gray-900 shadow-sm transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 dark:bg-slate-900 dark:text-white dark:hover:bg-slate-700"
+      >
+        Rent
+        <ChevronDown
+          aria-hidden="true"
+          className={`h-3.5 w-3.5 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div
+          id="rent-navigation-menu"
+          role="menu"
+          aria-label="Rent navigation"
+          className="absolute left-0 top-full z-50 mt-2 w-72 overflow-hidden rounded-xl border border-gray-100 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-800"
+        >
+          {RENT_ITEMS.map(({ icon: Icon, label, description, href }) => (
+            <Link
+              key={href}
+              href={href}
+              role="menuitem"
+              onClick={() => setOpen(false)}
+              className="flex items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 focus:bg-gray-50 focus:outline-none dark:hover:bg-slate-700 dark:focus:bg-slate-700"
+            >
+              <span className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-orange-100 dark:bg-orange-900/30">
+                <Icon aria-hidden="true" className="h-4 w-4 text-orange-500" />
+              </span>
+              <span>
+                <span className="block text-sm font-medium text-gray-900 dark:text-white">{label}</span>
+                <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">{description}</span>
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default function HotelHeader({ showHostSwitch = false }: HotelHeaderProps) {
@@ -26,13 +120,7 @@ export default function HotelHeader({ showHostSwitch = false }: HotelHeaderProps
         </Link>
 
         <div className="mx-auto hidden w-full max-w-[430px] items-center rounded-full border border-gray-200 bg-gray-100 px-2 py-1.5 md:flex dark:border-slate-700 dark:bg-slate-800">
-          <button
-            type="button"
-            className="flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm text-gray-900 shadow-sm dark:bg-slate-900 dark:text-white"
-          >
-            Rent
-            <FaChevronDown className="h-3.5 w-3.5" />
-          </button>
+          <RentDropdown />
           <div className="mx-3 h-6 w-px bg-gray-300 dark:bg-slate-600" />
           <span className="text-sm text-gray-500 dark:text-gray-300">
             City, province or neighborhood


### PR DESCRIPTION
## Summary

Connects the guest rental grid and curated suggestions experience through a shared Rent navigation dropdown and reciprocal page links. Guests can now move between browsing modes and reach their wishlist without manually entering URLs.

## Issue

Closes #444

## User impact and root cause

The existing Rent control looked like a dropdown but had no menu behavior, while `/rent` had no route to the curated suggestions view. Although current upstream already includes the suggestions page's “Browse all” link, navigation remained one-way and the header did not expose the three required destinations.

## Changes

- Replace the inert Rent control with an accessible dropdown containing Browse all units, Suggestions, and My Wishlist.
- Use semantic links so every destination supports standard browser navigation behavior.
- Add icons, descriptions, light/dark styles, hover states, and visible keyboard focus.
- Expose `aria-haspopup`, `aria-expanded`, `aria-controls`, menu, and menu-item semantics.
- Close the menu after selection, on outside click, and on Escape; Escape restores focus to the trigger.
- Add the reciprocal “Suggestions view” link beside Sort & Filter on `/rent`.
- Preserve the existing “Browse all” link on `/guest/suggestions`.
- Add focused component tests for destinations, selection close, outside click, and Escape focus restoration.

## Validation

- `git diff --check` passed.
- The focused Jest test and type check were not run because dependency installation timed out after 124 seconds before Jest or TypeScript binaries became available.
- No test result is being inferred or claimed from the incomplete installation.

## Notes

All destinations are route links and use the existing application paths: `/rent`, `/guest/suggestions`, and `/dashboard/favorites`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive Rent menu with quick links to rentals, suggestions, and favorites.
  - Added a Suggestions view link beside the rent page’s sorting and filtering controls.
  - Improved menu accessibility with keyboard support, focus restoration, and outside-click dismissal.

- **Tests**
  - Added coverage for Rent menu navigation, closing behavior, and keyboard interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->