### PR TITLE
fix: escrow dashboard scrollbar

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -107,7 +107,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
         <SideBar variant="permanent" notificationCount={1} />
       )}
 
-      <main className={`flex-1 transition-all duration-300 min-h-0 overflow-y-auto ${pathname !== "/dashboard/profile" ? "md:ml-16 lg:ml-48" : ""}`}>
+      <main className={`flex-1 transition-all duration-300 ${pathname !== "/dashboard/profile" ? "md:ml-16 lg:ml-48" : ""}`}>
         <div className={`w-full h-full ${pathname !== "/dashboard/profile" ? "p-4 md:p-8 lg:p-10" : "p-4 md:p-6"}`}>
           {children}
         </div>

--- a/src/components/layouts/SideBar.tsx
+++ b/src/components/layouts/SideBar.tsx
@@ -38,7 +38,7 @@ export function SideBar({
         className,
       )}
     >
-      <div className="flex flex-1 flex-col items-start gap-4 py-4 px-2 lg:px-4">
+      <div className="flex flex-1 flex-col items-start gap-4 py-4 px-2 lg:px-4 overflow-y-auto">
         <Link
           href="/dashboard/escrow"
           className={cn(


### PR DESCRIPTION
## Summary
Fixed escrow dashboard and overall dashboard scrollbar placement by removing overflow-y-auto and min-h-0 from main content in dashboard/layout.tsx, and adding overflow-y-auto to the inner sidebar nav container in SideBar.tsx.

## Changed files
- `src/app/dashboard/layout.tsx`
- `src/components/layouts/SideBar.tsx`

## Test plan
- Verified code changes match expected fix for issue #443.
- Tested compilation and component rendering via unit tests and code inspection.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #443


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard navigation scrolling when the sidebar links exceed the available screen height.
  * Adjusted dashboard content layout to prevent conflicting scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->